### PR TITLE
Fix: SQL queries using NOW() rely on MySQL timezone instead of shop timezone

### DIFF
--- a/statssearch.php
+++ b/statssearch.php
@@ -91,7 +91,7 @@ class statssearch extends ModuleGraph
     public function hookActionSearch($params)
     {
         $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'statssearch` (`id_shop`, `id_shop_group`, `keywords`, `results`, `date_add`)
-				VALUES (' . (int) $this->context->shop->id . ', ' . (int) $this->context->shop->id_shop_group . ', \'' . pSQL($params['expr']) . '\', ' . (int) $params['total'] . ', NOW())';
+				VALUES (' . (int) $this->context->shop->id . ', ' . (int) $this->context->shop->id_shop_group . ', \'' . pSQL($params['expr']) . '\', ' . (int) $params['total'] . ', \'' . date('Y-m-d H:i:s') . '\')';
         Db::getInstance()->execute($sql);
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | The search stats INSERT used \`NOW()\` to store \`date_add\`, which relies on the MySQL server timezone (UTC by default). Replaced with PHP's \`date('Y-m-d H:i:s')\` so the shop's configured timezone is used.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | Related to PrestaShop/PrestaShop#30828
| Related PRs       | PrestaShop/PrestaShop#41596
| Sponsor company   | PrestaShop SA

---
**Related CI issue:** #31